### PR TITLE
Restore home.html image resizing settings

### DIFF
--- a/home.html
+++ b/home.html
@@ -194,7 +194,7 @@
         left: 0;
         width: 100%;
         height: 100%;
-        object-fit: contain;
+        object-fit: cover;
         z-index: 1;
         filter: brightness(0.85) saturate(1.1);
         transition: var(--lynx-transition);


### PR DESCRIPTION
Revert `object-fit` for background images in `home.html` to fix unintended design breaks.

The `object-fit: contain` property was applied to `home.html` as part of a fix for image aspect ratio mismatches, but `home.html` was not affected by that issue. Instead, `contain` caused background images to not fill their containers, breaking the intended layout. This PR restores `object-fit: cover`, which is appropriate for these background images.