### PR TITLE
Remove "Yes" from house rules

### DIFF
--- a/house-rules.html
+++ b/house-rules.html
@@ -941,9 +941,6 @@
               <span class="rule-label">
                 Check-in & Check-out Times
               </span>
-              <span class="status-chip allowed"
-                >Yes</span
-              >
             </div>
             <div class="rule-content">
               <div class="time-settings">


### PR DESCRIPTION
Remove "Yes" status chip from "Check-in & Check-out Times" on house rules page.