### PR TITLE
Fix admin panel modal issue

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -436,6 +436,10 @@
             z-index: 1000;
         }
 
+        .modal.hidden {
+            display: none;
+        }
+
         .modal-content {
             background: var(--lynx-card);
             border-radius: var(--lynx-border-radius);


### PR DESCRIPTION
Add CSS rule to hide modal when `hidden` class is present, fixing unwanted modal display after login.