### PR TITLE
Enable auto-play for mobile video

### DIFF
--- a/wellness-spa.html
+++ b/wellness-spa.html
@@ -864,6 +864,8 @@
               autoplay
               muted
               loop
+              playsinline
+              preload="auto"
               style="
                 object-fit: contain;
                 border-radius: 14px;
@@ -1074,22 +1076,47 @@
       const wellnessVideo =
         document.getElementById("wellness-video");
 
-      // Ensure video autoplays when page loads
+      // Enhanced video autoplay for mobile devices
+      function attemptVideoPlay() {
+        if (wellnessVideo) {
+          wellnessVideo
+            .play()
+            .then(function() {
+              console.log("Video autoplay successful");
+            })
+            .catch(function (error) {
+              console.log(
+                "Video autoplay failed, trying user interaction:",
+                error
+              );
+              // For mobile devices, try to play on user interaction
+              document.addEventListener("touchstart", function() {
+                wellnessVideo.play().catch(function(err) {
+                  console.log("Touch play failed:", err);
+                });
+              }, { once: true });
+              
+              document.addEventListener("click", function() {
+                wellnessVideo.play().catch(function(err) {
+                  console.log("Click play failed:", err);
+                });
+              }, { once: true });
+            });
+        }
+      }
+
+      // Try autoplay when DOM is loaded
       document.addEventListener(
         "DOMContentLoaded",
-        function () {
-          if (wellnessVideo) {
-            wellnessVideo
-              .play()
-              .catch(function (error) {
-                console.log(
-                  "Video autoplay failed:",
-                  error
-                );
-              });
-          }
-        }
+        attemptVideoPlay
       );
+
+      // Also try when page is fully loaded (including video metadata)
+      window.addEventListener("load", function() {
+        if (wellnessVideo && wellnessVideo.paused) {
+          attemptVideoPlay();
+        }
+      });
     </script>
   </body>
 </html>


### PR DESCRIPTION
Enhance video autoplay on `wellness-spa.html` for improved mobile compatibility.

Mobile browsers often restrict video autoplay. This PR adds `playsinline` for iOS compatibility and implements a robust JavaScript fallback to play the video on the first user interaction if immediate autoplay is blocked.