### PR TITLE
Restore mobile share dialog functionality

### DIFF
--- a/food.html
+++ b/food.html
@@ -2008,10 +2008,10 @@
           // Show toast message first
           showToast("You're sharing the Airbnb listing for this apartment.");
           
-          // Open share functionality after 2 seconds
+          // Open share functionality immediately after toast
           setTimeout(() => {
             handleShare();
-          }, 2000);
+          }, 100); // Small delay to ensure toast appears first
         }
 
         // Share Functions


### PR DESCRIPTION
Restore immediate display of the mobile share dialog after the toast by reducing the delay.

A previous PR introduced a 2-second delay before the `navigator.share()` dialog appeared, which was not the desired behavior. This change reduces that delay to 100ms, ensuring the native share dialog appears almost immediately after the "sharing" toast.